### PR TITLE
Add Lumox to screen mirroring (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Table of Contents
 * [Shake](https://www.shakebugs.com/) :moneybag:
 * [Smartlook](https://www.smartlook.com/) :moneybag:
 * [Apptim](https://www.apptim.com/) :moneybag:
+* [LogDog](https://log.dog/) :moneybag:
 
 ### Cloud Testing
 
@@ -594,6 +595,7 @@ Table of Contents
 * [Burp](https://portswigger.net/burp/)
 * [Fiddler](http://www.telerik.com/fiddler)
 * [Proxyman](https://proxyman.io/) :moneybag:
+* [LogDog](https://log.dog/) :moneybag:
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Table of Contents
 
 ### iOS
 
+* [Lumox](https://lumox.app) - QuickTime Alternative: Create stunning product demos and tutorials for your mobile apps.
 * QuickTime
 
 ## Emulator/simulator


### PR DESCRIPTION
## Summary
- Add [Lumox](https://lumox.app) — QuickTime Alternative: Create stunning product demos and tutorials for your mobile apps.

## Test plan
- [x] Entry added in the appropriate section per repo guidelines
- [x] Alphabetical order checked where required
